### PR TITLE
Add selectors to resolved modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-sort-style-loom",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/index.js",
   "author": "Loom <team@loom.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ const style = ({
     || imported.moduleName.startsWith('constants/')
     || imported.moduleName.startsWith('creators/')
     || imported.moduleName.startsWith('middleware/')
+    || imported.moduleName.startsWith('selectors/')
     || imported.moduleName.startsWith('reducers/')
     || imported.moduleName.startsWith('utilities/');
 


### PR DESCRIPTION
`selectors/` should be in the list of resolved modules so that modules under `selectors/` are sorted correctly.